### PR TITLE
Feat/bin lib split with integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
     if: "!contains(toJSON(github.event.commits.*.message), '[skip ci]')"
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         rust: [stable, beta, nightly]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,14 @@ readme = "README.md"
 repository = "https://github.com/yamafaktory/craftql"
 version = "0.2.5-alpha.0"
 
+[lib]
+name = "craftql"
+path = "src/lib.rs"
+
+[[bin]]
+name = "craftql"
+path = "src/bin.rs"
+
 [dependencies]
 anyhow = "1.0.32"
 clap = "3.0.0-beta.1"

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -11,8 +11,10 @@ use craftql::{
         populate_graph_from_ast, print_missing_definitions,
     },
 };
-use petgraph::dot::{Config, Dot};
-use petgraph::Direction;
+use petgraph::{
+    dot::{Config, Dot},
+    Direction,
+};
 
 #[derive(Clap)]
 #[clap(author = crate_authors!(), about = crate_description!(), version = crate_version!())]

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -1,26 +1,16 @@
-//! # CraftQL
-//! TODO
-
 #![forbid(rust_2018_idioms)]
-#![warn(missing_debug_implementations, missing_docs)]
 #![deny(unsafe_code, nonstandard_style)]
 
-mod config;
-mod extend_types;
-mod state;
-mod utils;
-
-use crate::{
+use anyhow::Result;
+use async_std::path::PathBuf;
+use clap::{crate_authors, crate_description, crate_version, Clap};
+use craftql::{
     state::State,
     utils::{
         find_and_print_neighbors, find_and_print_orphans, find_node, get_files,
         populate_graph_from_ast, print_missing_definitions,
     },
 };
-
-use anyhow::Result;
-use async_std::path::PathBuf;
-use clap::{crate_authors, crate_description, crate_version, Clap};
 use petgraph::dot::{Config, Dot};
 use petgraph::Direction;
 
@@ -52,7 +42,7 @@ struct Opts {
 #[async_std::main]
 async fn main() -> Result<()> {
     let opts: Opts = Opts::parse();
-    let state = State::new();
+    let state = State::default();
     let shared_data = state.shared;
     let shared_data_for_populate = shared_data.clone();
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,1 +1,2 @@
+/// List of allowed file extensions.
 pub const ALLOWED_EXTENSIONS: [&str; 2] = ["graphql", "gql"];

--- a/src/extend_types.rs
+++ b/src/extend_types.rs
@@ -88,10 +88,15 @@ where
         .collect::<Vec<String>>()
 }
 
+/// Trait providing extension methods for graphql_parser::schema.
 pub trait ExtendType {
+    /// Method to get the dependencies.
     fn get_dependencies(&self) -> Vec<String>;
+    /// Method to get id and the name, id is optional and can be copied from name.
     fn get_id_and_name(&self) -> (Option<String>, String);
+    /// Method to get the internal GraphQL mapped type.
     fn get_mapped_type(&self) -> GraphQL;
+    /// Method to get the raw representation.
     fn get_raw(&self) -> String;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,15 @@
 #![forbid(rust_2018_idioms)]
-#![warn(missing_debug_implementations, missing_docs)]
+#![warn(missing_debug_implementations, missing_docs, unreachable_pub)]
 #![deny(unsafe_code, nonstandard_style)]
 
-//! TODO
+//! This library provides all the necessary methods and shared state for the craftql binary.
+//! Not meant to be used on its own! Primarily made for integration testing.
 
-///
+/// Main onfiguration.
 pub mod config;
-///
+/// Trait providing extension methods for graphql_parser::schema.
 pub mod extend_types;
-///
+/// Global state.
 pub mod state;
-///
+/// Utilities consumed by the binary.
 pub mod utils;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,14 @@
+#![forbid(rust_2018_idioms)]
+#![warn(missing_debug_implementations, missing_docs)]
+#![deny(unsafe_code, nonstandard_style)]
+
+//! TODO
+
+///
+pub mod config;
+///
+pub mod extend_types;
+///
+pub mod state;
+///
+pub mod utils;

--- a/src/state.rs
+++ b/src/state.rs
@@ -5,28 +5,40 @@ use async_std::{
 use petgraph::{graph::NodeIndex, Graph};
 use std::{collections::HashMap, fmt};
 
+/// Global state.
 #[derive(Debug)]
 pub struct State {
+    /// Shared part of the state.
     pub shared: Data,
 }
 
 /// Core GraphQL types used for definitions and extensions.
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum GraphQLType {
+    /// Enum type.
     Enum,
+    /// InputObject type.
     InputObject,
+    /// Interface type.
     Interface,
+    /// Object type.
     Object,
+    /// Scalar type.
     Scalar,
+    /// Union type.
     Union,
 }
 
 /// Derived and simplified from graphql_parser::schema enums.
 #[derive(Clone, PartialEq)]
 pub enum GraphQL<T = GraphQLType> {
+    /// Directive type.
     Directive,
+    /// Schema type.
     Schema,
+    /// TypeDefinition type.
     TypeDefinition(T),
+    /// TypeExtension type.
     TypeExtension(T),
 }
 
@@ -47,15 +59,22 @@ where
 /// Represents a GraphQL entity.
 #[derive(Clone)]
 pub struct Entity {
+    /// Dependencies of an entity.
     pub dependencies: Vec<String>,
+    /// GraphQL type of the entity.
     pub graphql: GraphQL,
+    /// Id of the entity.
     pub id: String,
+    /// Name of the entity.
     pub name: String,
+    /// Path of the entity.
     pub path: PathBuf,
+    /// Raw representation of the entity.
     pub raw: String,
 }
 
 impl Entity {
+    /// Method to create a new Entity.
     pub fn new(
         dependencies: Vec<String>,
         graphql: GraphQL,
@@ -103,14 +122,17 @@ impl fmt::Display for Entity {
     }
 }
 
+/// A Node containing an Entity and a unique id.
 pub struct Node {
+    /// Node's entity.
     pub entity: Entity,
-    // Using the entity name as id is safe as it is unique.
-    // http://spec.graphql.org/draft/#sec-Schema
+    /// Using the entity name as id is safe as it is unique.
+    /// http://spec.graphql.org/draft/#sec-Schema
     pub id: String,
 }
 
 impl Node {
+    /// Method to create a new Node.
     pub fn new(entity: Entity, id: String) -> Self {
         Node { entity, id }
     }
@@ -122,16 +144,21 @@ impl fmt::Debug for Node {
     }
 }
 
+/// Data holding the thread-safe mutexes.
 #[derive(Debug, Clone)]
 pub struct Data {
-    // Keep track of the dependencies for edges.
+    /// Dependencies mutex.
     pub dependencies: Arc<Mutex<HashMap<NodeIndex, Vec<String>>>>,
+    /// Files mutex.
     pub files: Arc<Mutex<HashMap<PathBuf, String>>>,
+    /// Graph mutex.
     pub graph: Arc<Mutex<petgraph::Graph<Node, (NodeIndex, NodeIndex)>>>,
+    /// Missing definition mutex.
     pub missing_definitions: Arc<Mutex<HashMap<NodeIndex, Vec<String>>>>,
 }
 
 impl State {
+    /// Method to create a new State.
     pub fn new() -> Self {
         State {
             shared: Data {
@@ -141,5 +168,11 @@ impl State {
                 missing_definitions: Arc::new(Mutex::new(HashMap::new())),
             },
         }
+    }
+}
+
+impl Default for State {
+    fn default() -> Self {
+        State::new()
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,0 +1,27 @@
+extern crate craftql;
+
+use anyhow::Result;
+use async_std::{fs, path::PathBuf};
+use craftql::{state::State, utils::get_files};
+
+#[async_std::test]
+async fn check_get_files() -> Result<()> {
+    let state = State::default();
+    let shared_data = state.shared;
+    let shared_data_cloned = shared_data.clone();
+
+    get_files(PathBuf::from("./tests/fixtures"), shared_data.files).await?;
+
+    let files = shared_data_cloned.files.lock().await;
+
+    assert_eq!(files.len(), 20);
+
+    let contents = fs::read_to_string("./tests/fixtures/Types/Enums/Episode.gql").await?;
+
+    assert_eq!(
+        files.get(&PathBuf::from("./tests/fixtures/Types/Enums/Episode.gql")),
+        Some(&contents)
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
In order to get proper integration tests, we need to split the project into a library and a binary.